### PR TITLE
LIBMOBILE-535 sovran fix unsubscribe implementation

### DIFF
--- a/lib/src/main/kotlin/sovran/kotlin/Store.kt
+++ b/lib/src/main/kotlin/sovran/kotlin/Store.kt
@@ -64,7 +64,7 @@ class Store {
     fun unsubscribe(subscriptionID: SubscriptionID) {
         runBlocking(syncQueue) {
             subscriptions.removeAll {
-                it.subscriptionID != subscriptionID
+                it.subscriptionID == subscriptionID
             }
         }
     }

--- a/lib/src/main/kotlin/sovran/kotlin/Store.kt
+++ b/lib/src/main/kotlin/sovran/kotlin/Store.kt
@@ -52,7 +52,7 @@ class Store {
                 notify(listOf(subscription), it)
             }
         }
-        return 0
+        return subscription.subscriptionID
     }
 
     /**

--- a/lib/src/main/kotlin/sovran/kotlin/Store.kt
+++ b/lib/src/main/kotlin/sovran/kotlin/Store.kt
@@ -201,7 +201,7 @@ class Store {
     data class Container(var state: State)
 
     internal class Subscription<StateT : State>(
-            obj: Any, val handler: Handler<StateT>,
+            obj: Subscriber, val handler: Handler<StateT>,
             val key: KClass<StateT>,
             val queue: CoroutineDispatcher
     ) {

--- a/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
+++ b/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
@@ -188,7 +188,13 @@ class SovranTest : Subscriber {
         val action = MessagesUnreadAction(22)
         store.dispatch(action, MessagesState::class)
 
+        val subscriptionCount = store.subscriptions.size
         store.unsubscribe(identifier)
+
+        // now the subscriptions should not have the one being unsubscribed
+        assertFalse(store.subscriptions.any{ it.subscriptionID == identifier })
+        // and the size should reduced only by 1
+        assertEquals(subscriptionCount - 1, store.subscriptions.size)
 
         // this should be ignored since we've unsubscribed.
         val nextAction = MessagesUnreadAction(11)

--- a/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
+++ b/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
@@ -40,7 +40,7 @@ class SovranTest : Subscriber {
         store.provide(UserState())
 
         // register some handlers for state changes
-        store.subscribe(this, MessagesState::class) { state ->
+        val id1 = store.subscribe(this, MessagesState::class) { state ->
             print("unreadCount = $state.unreadCount")
         }
 
@@ -50,14 +50,14 @@ class SovranTest : Subscriber {
         }
 
         // this should add a second listener for UserState
-        val identifier = store.subscribe(this, UserState::class) { state ->
+        val id3 = store.subscribe(this, UserState::class) { state ->
             print("username2 = $state.username")
         }
 
         // we should have 3 subscriptions.  2 for UserState, one for MessagesState.
         assertEquals(3, store.subscriptions.size)
         // the subscription id of the last one should be 3
-        assertEquals(3, identifier)
+        assertEquals(id1 + 2, id3)
     }
 
     @Test

--- a/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
+++ b/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
@@ -56,7 +56,8 @@ class SovranTest : Subscriber {
 
         // we should have 3 subscriptions.  2 for UserState, one for MessagesState.
         assertEquals(3, store.subscriptions.size)
-        // the subscription id of the last one should be 3
+        // we should have id1 + 2 = id3,
+        // since the subscription ID has been increased twice since id1
         assertEquals(id1 + 2, id3)
     }
 

--- a/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
+++ b/lib/src/test/kotlin/sovran/kotlin/SovranTest.kt
@@ -50,12 +50,14 @@ class SovranTest : Subscriber {
         }
 
         // this should add a second listener for UserState
-        store.subscribe(this, UserState::class) { state ->
+        val identifier = store.subscribe(this, UserState::class) { state ->
             print("username2 = $state.username")
         }
 
         // we should have 3 subscriptions.  2 for UserState, one for MessagesState.
         assertEquals(3, store.subscriptions.size)
+        // the subscription id of the last one should be 3
+        assertEquals(3, identifier)
     }
 
     @Test


### PR DESCRIPTION
**Summary**:
* fix unsubscribe logic where it suppose to remove a given subscription, but was remove all subscriptions except the given one
* fix subscribe logic where it suppose to return the subscription ID, but was always returning 0

**Additional Changes**:
* restrict Subscription object to be Subscriber instead of Any