### PR TITLE
Add a shutdown function to the Store to free resources.

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // Use the Kotlin JDK 8 standard library.
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
     // Use the Kotlin test library.
     testImplementation("org.jetbrains.kotlin:kotlin-test")


### PR DESCRIPTION
When the Analytics-Kotlin SDK is used in containerized environments that will auto scale we need to be able to free resources like ExecutorService/CoroutineDispatchers for a clean shutdown. 

This PR adds a shutdown() function to the Store to allow the Analytics SDK to also free up resources created by Sovran.